### PR TITLE
Add support for UTF-8 characters.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ const ping = (host, port = 25565, options, callback) => {
 			let parsed;
 
 			try {
-				parsed = JSON.parse(readingPacket.data.map((value) => String.fromCodePoint(value)).join(''));
+				parsed = JSON.parse(Buffer.from(readingPacket.data).toString("utf8"));
 			} catch (e) {
 				return reject(new Error('Invalid or corrupt payload data'));
 			}


### PR DESCRIPTION
Minecraft uses UTF-8 to represent its fonts. UTF-8 has certain characters that are represented by multiple code points as bytes, but as single characters in JavaScript. This PR adds support for those.

Tested by pinging `play.hivemc.com`. At the time of writing, it has several shapes in its MOTD. The current version of the library displays it as the following:

> §eâ§6â®§eâº §l§6The §l§eHive §eâ§6â®§eâº

This PR corrects it to the proper encoding so the actual symbols show up:

> §e◄§6▮§e► §l§6The §l§eHive §e◄§6▮§e►

(The §* options are Minecraft-specific [color and formatting codes](https://minecraft.gamepedia.com/Formatting_codes); those are intended to be there.)