### PR TITLE
Add support for Minecraft Forge mod data.

### DIFF
--- a/src/Structure/Response.js
+++ b/src/Structure/Response.js
@@ -18,6 +18,7 @@ class Response {
 		this.samplePlayers = 'players' in data && 'samplePlayers' in data.players ? data.players.samplePlayers : null;
 		this.descriptionText = descriptionText;
 		this.favicon = 'favicon' in data ? data.favicon : null;
+		this.modList = 'modinfo' in data && 'modList' in data.modinfo ? data.modinfo.modList : null;
 	}
 
 	getHost() {
@@ -58,6 +59,10 @@ class Response {
 
 	getFavicon() {
 		return this.favicon;
+	}
+
+	getModList() {
+		return this.modList;
 	}
 }
 

--- a/test/netty-rewrite.test.js
+++ b/test/netty-rewrite.test.js
@@ -31,6 +31,10 @@ for (let i = 0; i < servers.length; i++) {
 			expect(typeof data.descriptionText).toEqual('string');
 			expect(typeof data.favicon).toEqual('string');
 
+			if (data.modList != null) {
+				expect(data.modList).toBeInstanceOf(Array);
+			}
+
 			expect(data.onlinePlayers).toBeGreaterThanOrEqual(0);
 			expect(data.maxPlayers).toBeGreaterThanOrEqual(0);
 
@@ -50,6 +54,10 @@ for (let i = 0; i < servers.length; i++) {
 				expect(typeof data.samplePlayers).toEqual('object');
 				expect(typeof data.descriptionText).toEqual('string');
 				expect(typeof data.favicon).toEqual('string');
+
+				if (data.modList != null) {
+					expect(data.modList).toBeInstanceOf(Array);
+				}
 
 				expect(data.onlinePlayers).toBeGreaterThanOrEqual(0);
 				expect(data.maxPlayers).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
Minecraft Forge adds information about the server's mods to the ping response:
```javascript
{
    "modinfo": {
        "type": "FML",
        "modList": [
            {"modid": "forge", "version": "14.23.5.2838"},
            {"modid": "spongeforge", "version": "1.12.2-2838-7.1.8"},
            {"modid": "pixelmon", "version": "7.2.0"},
            // ...
        ]
    }
}
```

This PR adds support for the `modList` property from the Forge ping response. (The `type` property always seems to be `FML` when `modList` is present, so I don't think support for that is necessary.)