### PR TITLE
Fix samplePlayers always being null.

### DIFF
--- a/src/Structure/Response.js
+++ b/src/Structure/Response.js
@@ -15,7 +15,7 @@ class Response {
 		this.protocolVersion = 'version' in data && 'protocol' in data.version ? data.version.protocol : null;
 		this.onlinePlayers = 'players' in data && 'online' in data.players ? data.players.online : null;
 		this.maxPlayers = 'players' in data && 'max' in data.players ? data.players.max : null;
-		this.samplePlayers = 'players' in data && 'samplePlayers' in data.players ? data.players.samplePlayers : null;
+		this.samplePlayers = 'players' in data && 'sample' in data.players ? data.players.sample : null;
 		this.descriptionText = descriptionText;
 		this.favicon = 'favicon' in data ? data.favicon : null;
 	}


### PR DESCRIPTION
The player list is under `players.sample` in the original ping response, not `players.samplePlayers`.