### PR TITLE
Trap exception from Response constructor closer to the source

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,13 @@ const ping = (host, port = 25565, options, callback) => {
 
 			isResolved = true;
 
-			resolve(new Response(host, port, parsed));
+			try {
+				let response = new Response(host, port, parsed);
+				resolve(response);
+			}
+			catch(e) {
+				return reject(new Error('Invalid or corrupt payload data'));
+			}
 
 			socket.end();
 		});

--- a/src/index.js
+++ b/src/index.js
@@ -75,8 +75,6 @@ const ping = (host, port = 25565, options, callback) => {
 				return reject(new Error('Invalid or corrupt payload data'));
 			}
 
-			isResolved = true;
-
 			try {
 				let response = new Response(host, port, parsed);
 				resolve(response);
@@ -84,6 +82,8 @@ const ping = (host, port = 25565, options, callback) => {
 			catch(e) {
 				return reject(new Error('Invalid or corrupt payload data'));
 			}
+
+			isResolved = true;
 
 			socket.end();
 		});


### PR DESCRIPTION
My app is hitting those exceptions from the `Response` constructor while the minecraft servers are booting.
This PR prevents the exceptions from leaking out to the host app.

```
class Response {
	constructor(host, port, data) {
		if (typeof host !== 'string') throw new Error('Host must be a string');
		if (typeof port !== 'number') throw new Error('Port must be a number');
		if (typeof data !== 'object') throw new Error('Data must be an object');
		if (port < 1 || port > 65536) throw new Error('Port must be in range (0, 65536]');```