### PR TITLE
Fix hang-up when MC server discard packet after connect

### DIFF
--- a/test/netty-rewrite.test.js
+++ b/test/netty-rewrite.test.js
@@ -1,6 +1,7 @@
 const bluebird = require('bluebird');
 bluebird.config({ longStackTraces: true, warnings: true });
 global.Promise = bluebird;
+jest.setTimeout(8000);
 
 const ping = require('../src/index.js');
 


### PR DESCRIPTION
# Problem
Some servers (eg https://ddps.jp/) do not return a response after the socket connection is established (after Minecraft-Ping sends a packet).
Minecraft-Ping freezes without timing out.

# Fix
I used [socket.setTimeout(timeout[, callback])](https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback) and fixed it to time out.
