### PR TITLE
Add SRV record support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const net = require('net');
+const dns = require('dns');
 const Packet = require('./Structure/Packet');
 const Response = require('./Structure/Response');
 
@@ -21,7 +22,16 @@ const ping = (host, port = 25565, options, callback) => {
 	if (typeof port !== 'number') throw new TypeError('Port must be a number');
 	if (typeof options !== 'object') throw new TypeError('Options must be an object');
 
-	const resultPromise = new Promise((resolve, reject) => {
+	const resultPromise = new Promise(async (resolve, reject) => {
+		({ host, port } = await new Promise((resolve, reject) => {
+			dns.resolveSrv(`_minecraft._tcp.${host}`, (err, address) => {
+				resolve({
+					host: err ? host : (address?.[0]?.name ?? host),
+					port: err ? port : (address?.[0]?.port ?? port)
+				});
+			});
+		}));
+
 		let connectTimeout, isResolved = false;
 
 		const readingPacket = new Packet();

--- a/src/index.js
+++ b/src/index.js
@@ -23,14 +23,15 @@ const ping = (host, port = 25565, options, callback) => {
 	if (typeof options !== 'object') throw new TypeError('Options must be an object');
 
 	const resultPromise = new Promise(async (resolve, reject) => {
-		({ host, port } = await new Promise((resolve, reject) => {
-			dns.resolveSrv(`_minecraft._tcp.${host}`, (err, address) => {
-				resolve({
-					host: err ? host : (address?.[0]?.name ?? host),
-					port: err ? port : (address?.[0]?.port ?? port)
+		if (isNaN(Number(host.split('.').pop())))
+			({ host, port } = await new Promise((resolve, reject) => {
+				dns.resolveSrv(`_minecraft._tcp.${host}`, (err, address) => {
+					resolve({
+						host: err ? host : (address?.[0]?.name ?? host),
+						port: err ? port : (address?.[0]?.port ?? port)
+					});
 				});
-			});
-		}));
+			}));
 
 		let connectTimeout, isResolved = false;
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,8 @@ const ping = (host, port = 25565, options, callback) => {
 
 	options = Object.assign({
 		protocolVersion: 47,
-		connectTimeout: 1000 * 5
+		connectTimeout: 1000 * 5,
+		enableSRV: true
 	}, options);
 
 	if (typeof host !== 'string') throw new TypeError('Host must be a string');
@@ -23,13 +24,17 @@ const ping = (host, port = 25565, options, callback) => {
 	if (typeof options !== 'object') throw new TypeError('Options must be an object');
 
 	const resultPromise = new Promise(async (resolve, reject) => {
-		if (isNaN(Number(host.split('.').pop())))
+		if (options.enableSRV && isNaN(Number(host.split('.').pop())))
 			({ host, port } = await new Promise((resolve, reject) => {
 				dns.resolveSrv(`_minecraft._tcp.${host}`, (err, address) => {
-					resolve({
-						host: err ? host : (address?.[0]?.name ?? host),
-						port: err ? port : (address?.[0]?.port ?? port)
-					});
+					const addr = { host: host, port: port };
+					if (!err && address && address[0]) {
+						if (address[0].name)
+							addr.host = address[0].name;
+						if (address[0].port)
+							addr.port = address[0].port;
+					}
+					resolve(addr);
 				});
 			}));
 

--- a/test/netty-rewrite.test.js
+++ b/test/netty-rewrite.test.js
@@ -21,8 +21,8 @@ for (let i = 0; i < servers.length; i++) {
 		ping(servers[i], 25565, (error, data) => {
 			if (error) return done.fail(error);
 
-			expect(data.host).toEqual(servers[i]);
-			expect(data.port).toEqual(25565);
+			// expect(data.host).toEqual(servers[i]);
+			// expect(data.port).toEqual(25565);
 			expect(typeof data.version).toEqual('string');
 			expect(typeof data.protocolVersion).toEqual('number');
 			expect(typeof data.onlinePlayers).toEqual('number');
@@ -45,8 +45,8 @@ for (let i = 0; i < servers.length; i++) {
 	test(servers[i] + ' ping test, promise', (done) => {
 		ping(servers[i], 25565)
 			.then((data) => {
-				expect(data.host).toEqual(servers[i]);
-				expect(data.port).toEqual(25565);
+				// expect(data.host).toEqual(servers[i]);
+				// expect(data.port).toEqual(25565);
 				expect(typeof data.version).toEqual('string');
 				expect(typeof data.protocolVersion).toEqual('number');
 				expect(typeof data.onlinePlayers).toEqual('number');


### PR DESCRIPTION
# Problem
Some servers use Minecraft SRV record for use.

# Fix
Add DNS SRV record resolving.
(so host and ip test are not suitable)